### PR TITLE
CHANGE: Added caller argument to elfinderDialog()

### DIFF
--- a/summernote-ext-elfinder.js
+++ b/summernote-ext-elfinder.js
@@ -32,7 +32,7 @@
           contents: '<i class="fa fa-list-alt"/> File Manager',
           tooltip: 'elfinder',
           click: function () {
-              elfinderDialog();
+              elfinderDialog($(this).closest('.note-editor').parent().children('.summernote'));
           }
         });
         


### PR DESCRIPTION
With this patch the elfinderDialog() method gets the calling DOM element as argument.

This is helpfull if you use multiple elfinder and summernote instances on the same page.